### PR TITLE
Fixed issue sorting posts on Home

### DIFF
--- a/lib/blocks/recent-content.php
+++ b/lib/blocks/recent-content.php
@@ -38,6 +38,8 @@ function render_callback($attributes)
     $recent = new \WP_Query([
         'post_type' => 'post',
         'showposts' => 6,
+        'orderby' => 'date',
+        'order'   => 'DESC',
     ]);
 
     $output = '';


### PR DESCRIPTION
* [X] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [X] This is not a duplicate of an existing pull request

## Description

- Added ordering in the query that brought the recent posts

## Steps to test

1. Go to the Home page in the recent posts area

**Expected behavior: Posts presented must be in "Descending" order