### PR TITLE
Import user via CSV file

### DIFF
--- a/lib/import-csv/functions.php
+++ b/lib/import-csv/functions.php
@@ -53,7 +53,7 @@ function read_csv()
 
                 if ($user_id = email_exists($email)) {
                     if ($is_valid_event_id) {
-                        $event_ids = empty(get_user_meta($user_id, 'event_ids', true)) ? get_user_meta($user_id, 'event_ids', true) : [];
+                        $event_ids = !empty(get_user_meta($user_id, 'event_ids', true)) ? get_user_meta($user_id, 'event_ids', true) : [];
 
                         if (in_array($event_id, $event_ids)) {
                             $warnings[] = __("'$email' already registered in event ID $event_id", 'pcc-framework');
@@ -358,7 +358,7 @@ function removeslashes($string)
 add_filter('update_user_metadata', function ($check, $user_id, $meta_key, $meta_value) {
 
     if ($meta_key == 'event_ids') {
-        $current_user_events = empty(get_user_meta($user_id, 'event_ids', true)) ? get_user_meta($user_id, 'event_ids', true) : [];
+        $current_user_events = !empty(get_user_meta($user_id, 'event_ids', true)) ? get_user_meta($user_id, 'event_ids', true) : [];
         $new_events = array_diff($meta_value, $current_user_events);
 
         if (count($new_events) > 0) {

--- a/lib/import-csv/functions.php
+++ b/lib/import-csv/functions.php
@@ -23,7 +23,8 @@ function read_csv()
 
             $csv_file = fopen($_FILES['import_file']['tmp_name'], 'r');
 
-            $csv_headers = fgetcsv($csv_file);
+            $delimiter = detect_delimiter($_FILES['import_file']['tmp_name']);
+            $csv_headers = fgetcsv($csv_file, null, $delimiter);
 
 
             $email_index = array_search('email', $csv_headers);
@@ -93,7 +94,7 @@ function read_csv()
                         continue;
                     }
 
-                    $errors[] = __("The user '$email' was created but was not associated with event ID ($event_id) because the ID is not valid", 'pcc-framework');
+                    $warnings[] = __("The user '$email' was created but was not associated with event ID ($event_id) because the ID is not valid", 'pcc-framework');
                     continue;
                 }
 
@@ -109,6 +110,27 @@ function read_csv()
 
         endif;
     endif;
+}
+
+
+/**
+ * Detect CSV delimiter
+ *
+ * @param string $csv_file
+ * @return string
+ */
+function detect_delimiter($csv_file)
+{
+    $delimiters = [';' => 0, ',' => 0, '\t' => 0, '|' => 0];
+
+    $handle = fopen($csv_file, 'r');
+    $firstLine = fgets($handle);
+    fclose($handle); 
+    foreach ($delimiters as $delimiter => &$count) {
+        $count = count(str_getcsv($firstLine, $delimiter));
+    }
+
+    return array_search(max($delimiters), $delimiters);
 }
 
 

--- a/lib/import-csv/functions.php
+++ b/lib/import-csv/functions.php
@@ -29,8 +29,10 @@ function read_csv()
 
             $email_index = array_search('email', $csv_headers);
 
-            if ($email_index === false) {
-                return __('Column "email" not found!', 'pcc-framework');
+            if ($email_index == false) {
+                return [
+                    'errors' => [__('Column "email" not found!', 'pcc-framework')]
+                ];
             }
 
             $username_index = array_search('username', $csv_headers);

--- a/lib/import-csv/functions.php
+++ b/lib/import-csv/functions.php
@@ -24,8 +24,8 @@ function read_csv()
             $csv_file = fopen($_FILES['import_file']['tmp_name'], 'r');
 
             $delimiter = detect_delimiter($_FILES['import_file']['tmp_name']);
-            $csv_headers = fgetcsv($csv_file, null, $delimiter);
 
+            $csv_headers = fgetcsv($csv_file, 0, $delimiter);
 
             $email_index = array_search('email', $csv_headers);
 
@@ -38,7 +38,7 @@ function read_csv()
             $last_name_index = array_search('last_name', $csv_headers);
             $event_id_index = array_search('event_id', $csv_headers);
 
-            while (($csv_data = fgetcsv($csv_file)) !== FALSE) :
+            while (($csv_data = fgetcsv($csv_file, 0, $delimiter)) !== FALSE) :
                 $csv_data = array_map("utf8_encode", $csv_data);
 
                 $email = trim($csv_data[$email_index]);

--- a/lib/import-csv/functions.php
+++ b/lib/import-csv/functions.php
@@ -2,6 +2,12 @@
 
 namespace PCCFramework\Import_Users_Csv\Functions;
 
+
+/**
+ * Reads a CSV file and creates a new user and includes the user in an event.
+ *
+ * @return void
+ */
 function read_csv()
 {
 
@@ -105,6 +111,15 @@ function read_csv()
     endif;
 }
 
+
+/**
+ * Sends an email with the user's credentials after being created.
+ *
+ * @param string $user_email
+ * @param string $username
+ * @param string $password
+ * @return void
+ */
 function send_email_user_created($user_email, $username, $password)
 {
     $subject = !empty(get_option('user_csv_new_user_subject')) ? get_option('user_csv_new_user_subject') : get_default_text('user_subject');
@@ -131,6 +146,14 @@ function send_email_user_created($user_email, $username, $password)
 }
 
 
+/**
+ * Sends an email with information about the event in which the user was entered.
+ *
+ * @param string $user_email
+ * @param string $username
+ * @param int $event_id
+ * @return void
+ */
 function send_email_user_event($user_email, $username, $event_id)
 {
     $subject = !empty(get_option('user_csv_new_event_subject')) ? get_option('user_csv_new_event_subject') : get_default_text('event_subject');
@@ -163,6 +186,12 @@ function send_email_user_event($user_email, $username, $event_id)
 }
 
 
+/**
+ * Format results after reading and completion of CSV file import and returns an HTML string.
+ *
+ * @param array $results
+ * @return string
+ */
 function format_results($results)
 {
     $html = '';
@@ -186,6 +215,12 @@ function format_results($results)
     return $html;
 }
 
+
+/**
+ * Save email message settings.
+ *
+ * @return void
+ */
 function save_settings()
 {
     if (isset($_POST['save-user-csv-settings'])) {
@@ -201,6 +236,14 @@ function save_settings()
     }
 }
 
+
+/**
+ * Checks if the event ID is valid, it can be the Post ID or a unique value created on 
+ * the event page in the Open Collective event ID. It returns the Post ID or false.
+ *
+ * @param int|string $event_id
+ * @return int!false
+ */
 function is_valid_event($event_id)
 {
     if (!$event_id) return false;
@@ -225,6 +268,15 @@ function is_valid_event($event_id)
     return get_post_type($event_id) === 'pcc-event' ? $event_id : false;
 }
 
+
+
+/**
+ * Returns the default messages for sending emails
+ *
+ * @param string $type user_subject, event_subject, user_message or event_message depending 
+ * on whether the email is user creation or user inclusion in a certain event.
+ * @return string
+ */
 function get_default_text($type)
 {
     if ($type === 'user_subject') {
@@ -256,6 +308,14 @@ function get_default_text($type)
     }
 }
 
+
+
+/**
+ * Removes extra backslashes from email messages.
+ *
+ * @param string $string
+ * @return string
+ */
 function removeslashes($string)
 {
     $string = implode("", explode("\\", $string));
@@ -263,7 +323,16 @@ function removeslashes($string)
 }
 
 
-
+/**
+ * Sends email to the user if he is manually added to an event through the user profile.
+ *
+ * @link https://developer.wordpress.org/reference/hooks/update_meta_type_metadata/
+ * @param null|bool $check
+ * @param int $user_id
+ * @param mixed $meta_key
+ * @param mixed $meta_value
+ * @return bool
+ */
 add_filter('update_user_metadata', function ($check, $user_id, $meta_key, $meta_value) {
 
     if ($meta_key == 'event_ids') {

--- a/lib/import-csv/functions.php
+++ b/lib/import-csv/functions.php
@@ -2,6 +2,7 @@
 
 namespace PCCFramework\Import_Users_Csv\Functions;
 
+use SebastianBergmann\Environment\Console;
 
 /**
  * Reads a CSV file and creates a new user and includes the user in an event.
@@ -29,7 +30,8 @@ function read_csv()
 
             $email_index = array_search('email', $csv_headers);
 
-            if ($email_index == false) {
+            var_dump($email_index);
+            if ($email_index === false) {
                 return [
                     'errors' => [__('Column "email" not found!', 'pcc-framework')]
                 ];

--- a/lib/import-csv/functions.php
+++ b/lib/import-csv/functions.php
@@ -53,7 +53,7 @@ function read_csv()
 
                 if ($user_id = email_exists($email)) {
                     if ($is_valid_event_id) {
-                        $event_ids = get_user_meta($user_id, 'event_ids', true);
+                        $event_ids = empty(get_user_meta($user_id, 'event_ids', true)) ? get_user_meta($user_id, 'event_ids', true) : [];
 
                         if (in_array($event_id, $event_ids)) {
                             $warnings[] = __("'$email' already registered in event ID $event_id", 'pcc-framework');
@@ -358,7 +358,7 @@ function removeslashes($string)
 add_filter('update_user_metadata', function ($check, $user_id, $meta_key, $meta_value) {
 
     if ($meta_key == 'event_ids') {
-        $current_user_events = get_user_meta($user_id, 'event_ids', true) ? get_user_meta($user_id, 'event_ids', true) : [];
+        $current_user_events = empty(get_user_meta($user_id, 'event_ids', true)) ? get_user_meta($user_id, 'event_ids', true) : [];
         $new_events = array_diff($meta_value, $current_user_events);
 
         if (count($new_events) > 0) {

--- a/lib/import-csv/functions.php
+++ b/lib/import-csv/functions.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace PCCFramework\Import_Users_Csv\Functions;
+
+function read_csv()
+{
+
+    if (isset($_POST['importcsv'])) :
+
+        $extension = pathinfo($_FILES['import_file']['name'], PATHINFO_EXTENSION);
+
+        if (!empty($_FILES['import_file']['name']) && $extension == 'csv') :
+
+            $errors = [];
+            $warnings = [];
+            $success = 0;
+
+            $csv_file = fopen($_FILES['import_file']['tmp_name'], 'r');
+
+            $csv_headers = fgetcsv($csv_file);
+
+
+            $email_index = array_search('email', $csv_headers);
+
+            if ($email_index === false) {
+                return __('Column "email" not found!', 'pcc-framework');
+            }
+
+            $username_index = array_search('username', $csv_headers);
+            $fist_name_index = array_search('fist_name', $csv_headers);
+            $last_name_index = array_search('last_name', $csv_headers);
+            $event_id_index = array_search('event_id', $csv_headers);
+
+            while (($csv_data = fgetcsv($csv_file)) !== FALSE) :
+                $csv_data = array_map("utf8_encode", $csv_data);
+
+                $email = trim($csv_data[$email_index]);
+                $event_id = $event_id_index ? trim($csv_data[$event_id_index]) : null;
+                $event_id = is_valid_event($event_id);
+                $is_valid_event_id = $event_id && $event_id > 0;
+                
+                if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                    $errors[] = __("Email address '$email' is invalid.", 'pcc-framework');
+                    continue;
+                }
+
+                if ($user_id = email_exists($email)) {
+                    if ($is_valid_event_id) {
+                        $event_ids = get_user_meta($user_id, 'event_ids', true);
+
+                        if (in_array($event_id, $event_ids)) {
+                            $warnings[] = __("'$email' already registered in event ID $event_id", 'pcc-framework');
+                            continue;
+                        }
+
+                        $user = get_user_by('email', $email);
+                        $event_ids[] = $event_id;
+                        update_user_meta($user_id, 'event_ids', $event_ids);
+                        send_email_user_event($email, $user->user_login, $event_id);
+                        $success++;
+                        continue;
+                    }
+
+                    $errors[] = __("'$email' was not associated with event ID ($event_id) because the ID is not valid", 'pcc-framework');
+                    continue;
+                }
+
+                $password = wp_generate_password();
+                $username = $username_index && !empty(trim($csv_data[$username_index])) ? trim($csv_data[$username_index]) : strstr($email, '@', true);
+                $user_id = wp_insert_user([
+                    'user_pass' => $password,
+                    'user_login' => !username_exists($username) ? $username : $username . substr(md5(microtime()),rand(0,26),5),
+                    'user_email' => $email,
+                    'first_name' => $fist_name_index ? trim($csv_data[$fist_name_index]) : '',
+                    'last_name' => $last_name_index ? trim($csv_data[$last_name_index]) : '',
+                    'show_admin_bar_front' => false,
+                    'role' => 'external_user',
+                    'meta_input' => $is_valid_event_id ? ['event_ids' => [$event_id]] : null,
+                ]);
+
+                if ($user_id > 0) {
+                    send_email_user_created($email, $username, $password);
+
+                    if ($is_valid_event_id) {
+                        send_email_user_event($email, $username, $event_id);
+                        $success++;
+                        continue;
+                    }
+
+                    $errors[] = __("The user '$email' was created but was not associated with event ID ($event_id) because the ID is not valid", 'pcc-framework');
+                    continue;
+                }
+
+                $errors[] = __("Error creating user '$email'", 'pcc-framework');
+
+            endwhile;
+
+            return [
+                'errors' => $errors,
+                'warnings' => $warnings,
+                'success' => $success,
+            ];
+
+        endif;
+    endif;
+}
+
+function send_email_user_created($user_email, $username, $password)
+{
+    $subject = !empty(get_option('user_csv_new_user_subject')) ? get_option('user_csv_new_user_subject') : get_default_text('user_subject');
+    $message = !empty(get_option('user_csv_new_user_message')) ? get_option('user_csv_new_user_message') : get_default_text('user_message');
+
+    $subject = wp_unslash($subject);
+    $message = removeslashes($message);
+
+    $subject = str_replace("{{username}}", $username, $subject);
+    $subject = str_replace("{{user_email}}", $user_email, $subject);
+
+    $message = str_replace("{{username}}", $username, $message);
+    $message = str_replace("{{password}}", $password, $message);
+    $message = str_replace("{{user_email}}", $user_email, $message);
+
+    $headers = array('Content-Type: text/html; charset=UTF-8');
+
+    wp_mail(
+        $user_email,
+        $subject,
+        $message,
+        $headers
+    );
+}
+
+
+function send_email_user_event($user_email, $username, $event_id)
+{
+    $subject = !empty(get_option('user_csv_new_event_subject')) ? get_option('user_csv_new_event_subject') : get_default_text('event_subject');
+    $message = !empty(get_option('user_csv_new_event_message')) ? get_option('user_csv_new_event_message') : get_default_text('event_message');
+
+    $subject = wp_unslash($subject);
+    $message = removeslashes($message);
+
+    $event_title = get_the_title($event_id);
+    $event_url = get_permalink($event_id);
+
+    $subject = str_replace("{{username}}", $username, $subject);
+    $subject = str_replace("{{event_name}}", $event_title, $subject);
+    $subject = str_replace("{{user_email}}", $user_email, $subject);
+    $subject = str_replace("{{event_url}}", $event_url, $subject);
+
+    $message = str_replace("{{username}}", $username, $message);
+    $message = str_replace("{{event_name}}", $event_title, $message);
+    $message = str_replace("{{user_email}}", $user_email, $message);
+    $message = str_replace("{{event_url}}", $event_url, $message);
+
+    $headers = array('Content-Type: text/html; charset=UTF-8');
+
+    wp_mail(
+        $user_email,
+        $subject,
+        $message,
+        $headers
+    );
+}
+
+
+function format_results($results)
+{
+    $html = '';
+
+    if ($results['success'] > 0) {
+        $html .= "<p style=\"color: #398f39;\"><b>" . __('Success:', 'pcc-framework') . "</b> " . $results['success'] . __(' users added/updated', 'pcc-framework') . "</p>";
+    }
+    if ($results['warnings']) {
+        $html .= "<p style=\"color: #fda500;\"><b>" . __('Warnings:', 'pcc-framework') . "</b></p>";
+        foreach ($results['warnings'] as $warning) {
+            $html .= "<p style=\"color: #fda500;\">$warning</p>";
+        }
+    }
+    if ($results['errors']) {
+        $html .= "<p style=\"color: #eb2e2e;\"><b>" . __('Errors:', 'pcc-framework') . "</b></p>";
+        foreach ($results['errors'] as $error) {
+            $html .= "<p style=\"color: #eb2e2e;\">$error</p>";
+        }
+    }
+
+    return $html;
+}
+
+function save_settings()
+{
+    if (isset($_POST['save-user-csv-settings'])) {
+        $new_user_subject = isset($_POST['email-new-user-subject']) ? $_POST['email-new-user-subject'] : '';
+        $new_user_message = isset($_POST['email-new-user-message']) ? $_POST['email-new-user-message'] : '';
+        $event_subject = isset($_POST['email-event-subject']) ? $_POST['email-event-subject'] : '';
+        $event_message = isset($_POST['email-event-message']) ? $_POST['email-event-message'] : '';
+
+        update_option('user_csv_new_user_subject', $new_user_subject);
+        update_option('user_csv_new_user_message', $new_user_message);
+        update_option('user_csv_new_event_subject', $event_subject);
+        update_option('user_csv_new_event_message', $event_message);
+    }
+}
+
+function is_valid_event($event_id)
+{
+    if (!$event_id) return false;
+
+    if (!is_numeric($event_id)) {
+        $args = array(
+            'meta_key' => 'pcc_event_oc_id',
+            'meta_value' => $event_id,
+            'post_type' => 'pcc-event',
+            'post_status' => 'any',
+            'posts_per_page' => -1,
+            'fields' => 'ids',
+            'orderby' => 'date',
+            'order' => 'DESC',
+        );
+        $event_ids = get_posts($args);
+        wp_reset_postdata();
+
+        return $event_ids ? $event_ids[0] : false;
+    }
+    var_dump($event_id);
+    return get_post_type($event_id) === 'pcc-event' ? $event_id : false;
+}
+
+function get_default_text($type)
+{
+    if ($type === 'user_subject') {
+        return __("Welcome", 'pcc-framework');
+    }
+
+    if ($type === 'event_subject') {
+        return __("Now you can access the \"{{event_name}}\" event content", 'pcc-framework');
+    }
+
+    if ($type === 'user_message') {
+        return __("
+            <p>To log in, simply use this information:</p>
+            <table>
+                <tr>
+                    <td>Username: </td>
+                    <td>{{username}}</td>
+                </tr>
+                <tr>
+                    <td>Password: </td>
+                    <td>{{password}}</td>
+                </tr>
+            </table>", 'pcc-framework');
+    }
+
+    if ($type === 'event_message') {
+        return __("
+        <p>You can now access the event <a href=\"{{event_url}}\">\"{{event_name}}\"<\a></p>", 'pcc-framework');
+    }
+}
+
+function removeslashes($string)
+{
+    $string = implode("", explode("\\", $string));
+    return stripslashes(trim($string));
+}
+
+
+
+add_filter('update_user_metadata', function ($check, $user_id, $meta_key, $meta_value) {
+
+    if ($meta_key == 'event_ids') {
+        $current_user_events = get_user_meta($user_id, 'event_ids', true) ? get_user_meta($user_id, 'event_ids', true) : [];
+        $new_events = array_diff($meta_value, $current_user_events);
+
+        if (count($new_events) > 0) {
+            $user = get_user_by('ID', $user_id);
+
+            foreach ($new_events as $event_id) {
+                send_email_user_event($user->user_email, $user->user_login, $event_id);
+            }
+        }
+    }
+    return $check;
+}, 10, 4);

--- a/lib/import-csv/metabox.php
+++ b/lib/import-csv/metabox.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace PCCFramework\Import_Users_Csv\Metabox;
+
+function user_settings()
+{
+    $cmb = new_cmb2_box([
+        'id' => 'platformcoop_user_event_info',
+        'title' => __('User events', 'pcc-framework'),
+        'object_types' => ['user'],
+        'option_key' => 'platformcoop_user_event_info',
+        'capability' => 'edit_users',
+    ]);
+    $cmb->add_field([
+        'name' => __('Event list', 'pcc-framework'),
+        'id' => 'event_ids',
+        'type' => 'multicheck',
+        'options_cb' => '\\PCCFramework\\Import_Users_Csv\\Metabox\\user_event_list',
+        'column' => array(
+            'position' => 5,
+            'name'     => 'Events',
+        ),
+        'display_cb' => '\\PCCFramework\\Import_Users_Csv\\Metabox\\user_event_list_column'
+    ]);
+}
+
+
+function user_event_list($query_args)
+{
+
+    $args = [
+        'post_type' => 'pcc-event',
+        'numberposts' => -1
+    ];
+
+    $posts = query_posts($args);
+
+    $post_options = array();
+    if ($posts) {
+        foreach ($posts as $post) {
+            $post_options[$post->ID] = $post->post_title;
+        }
+    }
+
+    wp_reset_query();
+
+    return $post_options;
+}
+
+
+function user_event_list_column($field_args, $field)
+{
+    if ($field->escaped_value() && is_array($field->escaped_value())) :
+        foreach ($field->escaped_value() as $event_id) : ?>
+            <p><a href="<?= get_permalink($event_id); ?>"><?= get_the_title($event_id); ?><a></p>
+        <?php
+        endforeach;
+    endif;
+}
+
+
+

--- a/lib/import-csv/metabox.php
+++ b/lib/import-csv/metabox.php
@@ -2,6 +2,12 @@
 
 namespace PCCFramework\Import_Users_Csv\Metabox;
 
+
+/**
+ * Add event metabox in user profile and user event column in users table.
+ *
+ * @return void
+ */
 function user_settings()
 {
     $cmb = new_cmb2_box([
@@ -25,6 +31,12 @@ function user_settings()
 }
 
 
+/**
+ * Custom callback to return event list in user profile.
+ *
+ * @param array $query_args
+ * @return array
+ */
 function user_event_list($query_args)
 {
 
@@ -48,6 +60,13 @@ function user_event_list($query_args)
 }
 
 
+/**
+ * Custom callback to display user events in the users table.
+ *
+ * @param object $field_args
+ * @param object $field
+ * @return void
+ */
 function user_event_list_column($field_args, $field)
 {
     if ($field->escaped_value() && is_array($field->escaped_value())) :

--- a/lib/import-csv/page.php
+++ b/lib/import-csv/page.php
@@ -4,6 +4,13 @@ namespace PCCFramework\Import_Users_Csv\Page;
 
 use function PCCFramework\Import_Users_Csv\Functions\get_default_text;
 
+
+/**
+ * Add a subpage to the users page.
+ *
+ * @link https://developer.wordpress.org/reference/functions/add_submenu_page/
+ * @return void
+ */
 function init()
 {
     add_submenu_page(
@@ -16,6 +23,12 @@ function init()
     );
 }
 
+
+/**
+ * Callback with subpage content for importing CSV files and email message settings.
+ *
+ * @return void
+ */
 function content_page()
 {
     if (!current_user_can('create_users')) {
@@ -45,6 +58,12 @@ function content_page()
     <?php
 }
 
+
+/**
+ * HTML for CSV file import tab.
+ *
+ * @return void
+ */
 function import_file_tab()
 { ?>
         <div class="card">
@@ -63,6 +82,12 @@ function import_file_tab()
     <?php
 }
 
+
+/**
+ * HTML for e-mail settings tab.
+ *
+ * @return void
+ */
 function settings_tab()
 {
     $new_user_subject = !empty(get_option('user_csv_new_user_subject')) ? get_option('user_csv_new_user_subject') : get_default_text('user_subject');

--- a/lib/import-csv/page.php
+++ b/lib/import-csv/page.php
@@ -15,8 +15,8 @@ function init()
 {
     add_submenu_page(
         'users.php',
-        __('Import Users', 'pcc-framework'),
-        __('Import Users', 'pcc-framework'),
+        __('Import users from CSV', 'pcc-framework'),
+        __('Import users CSV', 'pcc-framework'),
         'create_users',
         'platformcoop_import_user',
         '\\PCCFramework\\Import_Users_Csv\\Page\\content_page'
@@ -39,7 +39,7 @@ function content_page()
     $tab = isset($_GET['tab']) ? $_GET['tab'] : $default_tab; ?>
 
     <div class="wrap">
-        <h1><?php _e('Import Users', 'pcc-framework'); ?></h1>
+        <h1><?php _e('Import users from CSV', 'pcc-framework'); ?></h1>
         <nav class="nav-tab-wrapper">
             <a href="?page=platformcoop_import_user" class="nav-tab <?php if ($tab === null) : ?>nav-tab-active<?php endif; ?>"><?php _e('Import file', 'pcc-framework'); ?></a>
             <a href="?page=platformcoop_import_user&tab=settings" class="nav-tab <?php if ($tab === 'settings') : ?>nav-tab-active<?php endif; ?>"><?php _e('E-mail settings', 'pcc-framework'); ?></a>
@@ -68,7 +68,11 @@ function import_file_tab()
 { ?>
         <div class="card">
             <h2><?php _e('Instructions', 'pcc-framework'); ?></h2>
-            <p><?php _e('The file MUST have "email" column for importing users.', 'pcc-framework'); ?></p>
+            <p><?php _e('Allowed columns: <b>email</b>, <b>event_id</b>, <b>username</b>, <b>fist_name</b>, <b>last_name</b>.', 'pcc-framework'); ?></p>
+            <p><?php _e('The file <b>MUST</b> have <b>email</b> column for importing users.', 'pcc-framework'); ?></p>
+            <p><?php _e('If the <b>event_id</b> column does not exist or if the user does not have an event id in the file, the user will be created but not linked to the event.', 'pcc-framework'); ?></p>
+            <p><?php _e('The columns <b>username</b>, <b>fist_name</b>, <b>last_name</b> are optional.', 'pcc-framework'); ?></p>
+            <p><?php _e('If the <b>username</b> column does not exist, the username will be generated from the email.', 'pcc-framework'); ?></p>
             <form method='post' action='<?= $_SERVER['REQUEST_URI']; ?>' enctype='multipart/form-data'>
                 <p><input type="file" name="import_file"></p>
                 <p class="submit"><input type="submit" name="importcsv" id="importcsv" class="button button-secondary" value="Load File"></p>

--- a/lib/import-csv/page.php
+++ b/lib/import-csv/page.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace PCCFramework\Import_Users_Csv\Page;
+
+use function PCCFramework\Import_Users_Csv\Functions\get_default_text;
+
+function init()
+{
+    add_submenu_page(
+        'users.php',
+        __('Import Users', 'pcc-framework'),
+        __('Import Users', 'pcc-framework'),
+        'create_users',
+        'platformcoop_import_user',
+        '\\PCCFramework\\Import_Users_Csv\\Page\\content_page'
+    );
+}
+
+function content_page()
+{
+    if (!current_user_can('create_users')) {
+        return;
+    }
+
+    $default_tab = null;
+    $tab = isset($_GET['tab']) ? $_GET['tab'] : $default_tab; ?>
+
+    <div class="wrap">
+        <h1><?php _e('Import Users', 'pcc-framework'); ?></h1>
+        <nav class="nav-tab-wrapper">
+            <a href="?page=platformcoop_import_user" class="nav-tab <?php if ($tab === null) : ?>nav-tab-active<?php endif; ?>"><?php _e('Import file', 'pcc-framework'); ?></a>
+            <a href="?page=platformcoop_import_user&tab=settings" class="nav-tab <?php if ($tab === 'settings') : ?>nav-tab-active<?php endif; ?>"><?php _e('E-mail settings', 'pcc-framework'); ?></a>
+        </nav>
+        <div class="tab-content">
+            <?php switch ($tab):
+                case 'settings':
+                    settings_tab();
+                    break;
+
+                default:
+                    import_file_tab();
+                    break;
+            endswitch; ?>
+        </div>
+    <?php
+}
+
+function import_file_tab()
+{ ?>
+        <div class="card">
+            <h2><?php _e('Instructions', 'pcc-framework'); ?></h2>
+            <p><?php _e('The file MUST have "email" column for importing users.', 'pcc-framework'); ?></p>
+            <form method='post' action='<?= $_SERVER['REQUEST_URI']; ?>' enctype='multipart/form-data'>
+                <p><input type="file" name="import_file"></p>
+                <p class="submit"><input type="submit" name="importcsv" id="importcsv" class="button button-secondary" value="Load File"></p>
+            </form>
+            <?php $results = \PCCFramework\Import_Users_Csv\Functions\read_csv(); ?>
+            <?php if ($results) : ?>
+                <h2><?php _e('Status', 'pcc-framework'); ?></h2>
+                <?= \PCCFramework\Import_Users_Csv\Functions\format_results($results); ?>
+            <?php endif; ?>
+        </div>
+    <?php
+}
+
+function settings_tab()
+{
+    $new_user_subject = !empty(get_option('user_csv_new_user_subject')) ? get_option('user_csv_new_user_subject') : get_default_text('user_subject');
+    $new_user_message = !empty(get_option('user_csv_new_user_message')) ? get_option('user_csv_new_user_message') : get_default_text('user_message');
+    $event_subject = !empty(get_option('user_csv_new_event_subject')) ? get_option('user_csv_new_event_subject') : get_default_text('event_subject');
+    $event_message = !empty(get_option('user_csv_new_event_message')) ? get_option('user_csv_new_event_message') : get_default_text('event_message');
+    ?>
+
+        <form id="user-csv-settings" method="post" action="">
+            <h2><?php _e('User created', 'pcc-framework'); ?></h2>
+            <table class="form-table">
+                <tbody>
+                    <tr valign="top">
+                        <th scope="row"><label for="email-new-user-subject"><?php _e('Subject', 'pcc-framework'); ?></label></th>
+                        <td>
+                            <input id="email-new-user-subject" type="text" name="email-new-user-subject" autocomplete="off" value="<?= stripslashes(htmlentities($new_user_subject)); ?>">
+                        </td>
+                    </tr>
+                    <tr valign="top">
+                        <th scope="row"><label for="email-new-user-message"><?php _e('Message', 'pcc-framework'); ?></label></th>
+                        <td>
+                            <textarea id="email-new-user-message" name="email-new-user-message" class="large-text" rows="10" autocomplete="off"><?= \PCCFramework\Import_Users_Csv\Functions\removeslashes($new_user_message); ?></textarea>
+                            <p class="description"><?php _e('Use <b>{{username}}</b> to indicate username', 'pcc-framework'); ?></p>
+                            <p class="description"><?php _e('Use <b>{{password}}</b> to indicate the user\'s password', 'pcc-framework'); ?></p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <h3><?php _e('User added to an event', 'pcc-framework'); ?></h3>
+            <table class="form-table">
+                <tbody>
+                    <tr valign="top">
+                        <th scope="row"><label for="email-event-subject"><?php _e('Subject', 'pcc-framework'); ?></label></th>
+                        <td>
+                            <input id="email-event-subject" type="text" name="email-event-subject" autocomplete="off" value="<?= stripslashes(htmlentities($event_subject)); ?>">
+                        </td>
+                    </tr>
+                    <tr valign="top">
+                        <th scope="row"><label for="email-event-message"><?php _e('Message', 'pcc-framework'); ?></label></th>
+                        <td>
+                            <textarea id="email-event-message" name="email-event-message" class="large-text" rows="10" autocomplete="off"><?= \PCCFramework\Import_Users_Csv\Functions\removeslashes($event_message); ?></textarea>
+                            <p class="description"><?php _e('Use <b>{{username}}</b> to indicate username', 'pcc-framework'); ?></p>
+                            <p class="description"><?php _e('Use <b>{{event_name}}</b> to indicate the event name', 'pcc-framework'); ?></p>
+                            <p class="description"><?php _e('Use <b>{{event_url}}</b> to indicate the event URL', 'pcc-framework'); ?></p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <p class="submit"><input type="submit" name="save-user-csv-settings" id="save-user-csv-settings" class="button button-primary" value="Save settings"></p>
+        </form>
+    <?php
+}

--- a/lib/posttypes/pcc-event.php
+++ b/lib/posttypes/pcc-event.php
@@ -179,6 +179,7 @@ function data()
             'conference' => __('PCC Conference', 'pcc-framework'),
             'pcc' => __('PCC Event', 'pcc-framework'),
             'icde' => __('ICDE Event', 'pcc-framework'),
+            'course' => __('Course', 'pcc-framework'),
         ],
         'show_on_cb' => 'PCCFramework\PostTypes\Event\is_parent_event',
         'description' =>

--- a/lib/posttypes/pcc-event.php
+++ b/lib/posttypes/pcc-event.php
@@ -97,7 +97,7 @@ function data()
         'id' => $prefix . 'start',
         'type' => 'text_datetime_timestamp',
         'description' =>
-            __('The date and time at which the event begins.', 'pcc-framework'),
+        __('The date and time at which the event begins.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
@@ -105,7 +105,7 @@ function data()
         'id' => $prefix . 'end',
         'type' => 'text_datetime_timestamp',
         'description' =>
-            __('The date and time at which the event ends.', 'pcc-framework'),
+        __('The date and time at which the event ends.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
@@ -113,7 +113,7 @@ function data()
         'id'   => $prefix . 'venue',
         'type' => 'textarea_small',
         'description' =>
-            __('The name of the event&rsquo;s principal venue.', 'pcc-framework'),
+        __('The name of the event&rsquo;s principal venue.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
@@ -121,7 +121,7 @@ function data()
         'id'   => $prefix . 'venue_street_address',
         'type' => 'text',
         'description' =>
-            __('The street address of the event&rsquo;s principal venue.', 'pcc-framework'),
+        __('The street address of the event&rsquo;s principal venue.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
@@ -129,7 +129,7 @@ function data()
         'id'   => $prefix . 'venue_locality',
         'type' => 'text',
         'description' =>
-            __('The town or city of the event&rsquo;s principal venue.', 'pcc-framework'),
+        __('The town or city of the event&rsquo;s principal venue.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
@@ -137,7 +137,7 @@ function data()
         'id'   => $prefix . 'venue_region',
         'type' => 'text',
         'description' =>
-            __('The province, state, or region of the event&rsquo;s principal venue.', 'pcc-framework'),
+        __('The province, state, or region of the event&rsquo;s principal venue.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
@@ -145,7 +145,7 @@ function data()
         'id'   => $prefix . 'venue_postal_code',
         'type' => 'text',
         'description' =>
-            __('The postal code of the event&rsquo;s principal venue.', 'pcc-framework'),
+        __('The postal code of the event&rsquo;s principal venue.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
@@ -155,7 +155,7 @@ function data()
         'default' => 'US',
         'options' => $countries,
         'description' =>
-            __('The country of the event&rsquo;s principal venue.', 'pcc-framework'),
+        __('The country of the event&rsquo;s principal venue.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
@@ -165,7 +165,7 @@ function data()
         'protocols' => ['http', 'https'],
         'show_on_cb' => 'PCCFramework\PostTypes\Event\is_parent_event',
         'description' =>
-            __('A hyperlink to the event&rsquo;s external registration page.', 'pcc-framework'),
+        __('A hyperlink to the event&rsquo;s external registration page.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
@@ -182,7 +182,7 @@ function data()
         ],
         'show_on_cb' => 'PCCFramework\PostTypes\Event\is_parent_event',
         'description' =>
-            __('The type of event.', 'pcc-framework'),
+        __('The type of event.', 'pcc-framework'),
     ]);
 
     $cmb->add_field([
@@ -201,7 +201,7 @@ function data()
     $cmb->add_field([
         'name' => __('Participants', 'pcc-framework'),
         'desc' =>
-            'Participants will be shown alphabetically on the participants page.',
+        'Participants will be shown alphabetically on the participants page.',
         'id'   => $prefix . 'participants',
         'type' => 'select',
         'show_option_none' => true,
@@ -215,7 +215,7 @@ function data()
     $cmb->add_field([
         'name' => __('Featured Participants', 'pcc-framework'),
         'desc' =>
-            'Featured participants will be shown in this order on the main event page.',
+        'Featured participants will be shown in this order on the main event page.',
         'id'   => $prefix . 'featured_participants',
         'type' => 'select',
         'show_option_none' => true,
@@ -224,6 +224,67 @@ function data()
         'text' => [
             'add_row_text' => __('Add Featured Participant', 'pcc-framework'),
         ]
+    ]);
+
+    $cmb_oc = new_cmb2_box([
+        'id'            => 'event_oc',
+        'title'         => __('Open Collective', 'pcc-framework'),
+        'object_types'  => ['pcc-event'],
+        'context'       => 'normal',
+        'priority'      => 'high',
+        'show_names'    => true,
+    ]);
+
+    $cmb_oc->add_field([
+        'name' => __('Paid event?', 'pcc-framework'),
+        'id' => $prefix . 'oc_paid',
+        'type' => 'checkbox',
+        'description' =>
+        __('Check this option if the event can only be accessed after purchasing access to it.', 'pcc-framework'),
+    ]);
+
+    $cmb_oc->add_field([
+        'name' => __('Open Collective event ID', 'pcc-framework'),
+        'id' => $prefix . 'oc_id',
+        'type' => 'text_medium',
+        'description' =>
+        __('You can leave it blank if you want to use the default event ID.<br/> (This ID is the same one used to import the list of users through the CSV file).', 'pcc-framework'),
+    ]);
+
+    $cmb_oc->add_field([
+        'name' => __('Collective slug', 'pcc-framework'),
+        'id' => $prefix . 'oc_collective_slug',
+        'type' => 'text_medium',
+    ]);
+
+    $cmb_oc->add_field([
+        'name' => __('Collective button type', 'pcc-framework'),
+        'id' => $prefix . 'oc_button_type',
+        'type'             => 'radio',
+        'show_option_none' => false,
+        'options'          => array(
+            'contribute' => __('Contribute', 'pcc-framework'),
+            'donate' => __('Donate', 'pcc-framework'),
+        ),
+        'default' => 'contribute',
+    ]);
+
+    $cmb_oc->add_field([
+        'name' => __('Collective button color', 'pcc-framework'),
+        'id' => $prefix . 'oc_button_color',
+        'type'             => 'radio',
+        'show_option_none' => false,
+        'options'          => array(
+            'white' => __('White', 'pcc-framework'),
+            'blue' => __('Blue', 'pcc-framework'),
+        ),
+        'default' => 'white',
+    ]);
+
+    $cmb_oc->add_field([
+        'name' => __('Content before the payment link', 'pcc-framework'),
+        'id' => $prefix . 'oc_content_before_link',
+        'type' => 'wysiwyg',
     ]);
 }
 

--- a/pcc-framework.php
+++ b/pcc-framework.php
@@ -116,6 +116,7 @@ if (is_admin()) {
     add_action('cmb2_admin_init', '\\PCCFramework\\PostTypes\\Story\\data');
     add_action('cmb2_admin_init', '\\PCCFramework\\Settings\\configuration');
     add_action('cmb2_admin_init', '\\PCCFramework\\Settings\\localization');
+    add_action('cmb2_admin_init', '\\PCCFramework\\Import_Users_Csv\\Metabox\\user_settings');
     add_filter('attachment_fields_to_edit', '\\PCCFramework\\PostTypes\\Attachment\\data', 10, 2);
     add_action('edit_attachment', '\\PCCFramework\\PostTypes\\Attachment\\save');
 }
@@ -125,8 +126,51 @@ add_action('init', '\\PCCFramework\\Intervention\\apply_interventions');
 
 
 /**
+ * Load admin assets and metadata fields.
+ */
+require_once dirname(__FILE__) . '/lib/import-csv/page.php';
+require_once dirname(__FILE__) . '/lib/import-csv/metabox.php';
+require_once dirname(__FILE__) . '/lib/import-csv/functions.php';
+
+add_action('admin_menu', '\\PCCFramework\\Import_Users_Csv\\Page\\init');
+add_action('init', '\\PCCFramework\\Import_Users_Csv\\Functions\\save_settings');
+
+
+
+/**
  * Register new embed providers.
  */
 require_once dirname(__FILE__) . "/lib/embeds.php";
 
 PCCFramework\Embeds\init_livestream();
+
+
+/**
+ * Add ID column to Events admin page
+ */
+add_filter('manage_pcc-event_posts_columns', function($columns) {
+    $new_columns = [];
+    $event_id = __('ID', 'pcc-framework');
+
+    foreach($columns as $key=>$value) {
+        if($key=='title') { 
+           $new_columns['event_id'] = $event_id; 
+        }    
+        $new_columns[$key]=$value;
+    }  
+
+    return $new_columns;
+});
+ 
+add_action('manage_pcc-event_posts_custom_column', function($column_key, $post_id) {
+	if ($column_key == 'event_id') {
+		echo $post_id;
+	}
+}, 10, 2);
+
+add_action('admin_head', function () {
+    echo '<style type="text/css">';
+    echo '.column-event_id { width:60px !important; }';
+    echo '</style>';
+});
+


### PR DESCRIPTION
* [X] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [X] This is not a duplicate of an existing pull request

## Description

- Adds a submenu in the Users menu for importing users via CSV
- The import page has a field for importing the file and a tab for configuring the messages that the user will receive
- Event listing page now shows event ID
- User events can be edited manually in user profile and user will be notified of new event
- In the event editor there are new fields for Open Collective information to generate the donation/contribution button and with the option to show content before the button

## Steps to test

1. Go to Admin > Users > Import users CSV
2. Choose a CSV file that is within the parameters mentioned in the instructions and click on Load File

**Expected behavior: A log will be displayed after the file has been loaded and the emails sent