### PR TITLE
Modified display conditions for event fields

### DIFF
--- a/lib/posttypes/pcc-event.php
+++ b/lib/posttypes/pcc-event.php
@@ -204,6 +204,7 @@ function data()
             'instructor' => __('Instructor', 'pcc-framework'),
             'coach' => __('Coach', 'pcc-framework'),
         ),
+        'show_on_cb' => 'PCCFramework\PostTypes\Event\is_parent_event',
         'attributes'    => array(
             'data-conditional-id'     => $prefix . 'type',
             'data-conditional-value'  => wp_json_encode(array('course', 'past_course')),
@@ -258,6 +259,7 @@ function data()
         'context'       => 'normal',
         'priority'      => 'high',
         'show_names'    => true,
+        'show_on_cb' => 'PCCFramework\PostTypes\Event\is_parent_event',
     ]);
 
     $cmb_oc->add_field([

--- a/lib/posttypes/pcc-event.php
+++ b/lib/posttypes/pcc-event.php
@@ -119,11 +119,28 @@ function data()
     ]);
 
     $cmb->add_field([
+        'name' => __('Format', 'pcc-framework'),
+        'id' => $prefix . 'format',
+        'type' => 'radio',
+        'default' => 'not_online',
+        'options' => array(
+            'not_online' => __('Face-to-face', 'pcc-framework'),
+            'async' => __('Online Asynchronous', 'pcc-framework'),
+            'sync' => __('Online Synchronous', 'pcc-framework'),
+            'async_sync' => __('Online Asynchronous and Synchronous', 'pcc-framework'),
+        ),
+    ]);
+
+    $cmb->add_field([
         'name' => __('Venue Name', 'pcc-framework'),
         'id'   => $prefix . 'venue',
         'type' => 'textarea_small',
         'description' =>
         __('The name of the event&rsquo;s principal venue.', 'pcc-framework'),
+        'attributes'    => array(
+            'data-conditional-id'     => $prefix . 'format',
+            'data-conditional-value'  => 'not_online',
+        ),
     ]);
 
     $cmb->add_field([
@@ -132,6 +149,10 @@ function data()
         'type' => 'text',
         'description' =>
         __('The street address of the event&rsquo;s principal venue.', 'pcc-framework'),
+        'attributes'    => array(
+            'data-conditional-id'     => $prefix . 'format',
+            'data-conditional-value'  => 'not_online',
+        ),
     ]);
 
     $cmb->add_field([
@@ -140,6 +161,10 @@ function data()
         'type' => 'text',
         'description' =>
         __('The town or city of the event&rsquo;s principal venue.', 'pcc-framework'),
+        'attributes'    => array(
+            'data-conditional-id'     => $prefix . 'format',
+            'data-conditional-value'  => 'not_online',
+        ),
     ]);
 
     $cmb->add_field([
@@ -148,6 +173,10 @@ function data()
         'type' => 'text',
         'description' =>
         __('The province, state, or region of the event&rsquo;s principal venue.', 'pcc-framework'),
+        'attributes'    => array(
+            'data-conditional-id'     => $prefix . 'format',
+            'data-conditional-value'  => 'not_online',
+        ),
     ]);
 
     $cmb->add_field([
@@ -156,6 +185,10 @@ function data()
         'type' => 'text',
         'description' =>
         __('The postal code of the event&rsquo;s principal venue.', 'pcc-framework'),
+        'attributes'    => array(
+            'data-conditional-id'     => $prefix . 'format',
+            'data-conditional-value'  => 'not_online',
+        ),
     ]);
 
     $cmb->add_field([
@@ -166,6 +199,10 @@ function data()
         'options' => $countries,
         'description' =>
         __('The country of the event&rsquo;s principal venue.', 'pcc-framework'),
+        'attributes'    => array(
+            'data-conditional-id'     => $prefix . 'format',
+            'data-conditional-value'  => 'not_online',
+        ),
     ]);
 
     $cmb->add_field([


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

- Additional event information fields will only be shown in the parent event

## Steps to test

1. Create a child post sa Course type event;
2. See if fields like event type and payment information are hidden.

## Additional information


