### PR TITLE
Removed Open Collective checkbox

### DIFF
--- a/lib/posttypes/pcc-event.php
+++ b/lib/posttypes/pcc-event.php
@@ -367,14 +367,6 @@ function data()
     ]);
 
     $cmb_oc->add_field([
-        'name' => __('Paid event?', 'pcc-framework'),
-        'id' => $prefix . 'oc_paid_event',
-        'type' => 'checkbox',
-        'description' =>
-        __('Check this option if the event can only be accessed after purchasing access to it.', 'pcc-framework'),
-    ]);
-
-    $cmb_oc->add_field([
         'name' => __('Event URL', 'pcc-framework'),
         'id' => $prefix . 'oc_event_link',
         'type' => 'text',


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

- Removed the checkbox that defines if the event is paid. Now it's defined by the value in the event price field.

## Steps to test

1. Create an event and fill the fields;
2. Set the event price;
3. See if the price will display correctly in event descriptions.

## Additional information


