### PR TITLE
Changed old meta_key to list events

### DIFF
--- a/lib/import-csv/metabox.php
+++ b/lib/import-csv/metabox.php
@@ -41,16 +41,17 @@ function user_event_list($query_args)
 {
 
     $args = array(
-        'meta_key' => 'pcc_event_oc_paid_event',
-        'meta_value' => 'on',
+        'meta_key' => 'pcc_event_type',
+        'meta_value' => ['course', 'past_course'],
         'post_type' => 'pcc-event',
         'post_status' => 'any',
         'posts_per_page' => -1,
         'orderby' => 'date',
         'order' => 'DESC',
+        'post_parent' => 0,
     );
     $posts = get_posts($args);
-    
+
     $post_options = array();
     if ($posts) {
         foreach ($posts as $post) {


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

- Replaced old meta_key with pcc_event_type meta_key and changed its meta_value to 'course' and 'past_course'.

## Steps to test

1. Go to users page;
2. Enter a user's profile and check at the bottom of the page that the courses are being listed.

## Additional information